### PR TITLE
feat: support nv pcr policy

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -668,6 +668,7 @@ pub fn backup_tor_keys_to_tpm(
     nv_handle: NvIndexHandle,
     nv_size: usize,
     relays: &[ResolvedRelayRecord],
+    pcr_indices: &[u8],
 ) -> anyhow::Result<()> {
     println!("Backing up Tor relay keys to TPM...");
 
@@ -676,7 +677,7 @@ pub fn backup_tor_keys_to_tpm(
     let mut padded_data = serialized;
     padded_data.resize(nv_size, 0);
 
-    nv_write_data(ctx, nv_handle, &padded_data)?;
+    nv_write_data_with_policy(ctx, nv_handle, &padded_data, pcr_indices)?;
 
     println!("Successfully backed up {} relay keys to TPM", relays.len());
     Ok(())
@@ -685,12 +686,12 @@ pub fn backup_tor_keys_to_tpm(
 pub fn restore_tor_keys_from_tpm(
     ctx: &mut TpmContext,
     nv_handle: NvIndexHandle,
-    _nv_size: usize,
     relays: &[ResolvedRelayRecord],
+    pcr_indices: &[u8],
 ) -> anyhow::Result<()> {
     println!("Restoring Tor relay keys from TPM");
 
-    let data = nv_read_data(ctx, nv_handle)?;
+    let data = nv_read_data_with_policy(ctx, nv_handle, pcr_indices)?;
     let restored_keys = deserialize_relay_keys(&data)?;
 
     // Restore family key to all relay key dirs

--- a/client/src/tpm.rs
+++ b/client/src/tpm.rs
@@ -5,11 +5,11 @@ use tss_esapi::constants::SessionType;
 use tss_esapi::handles::{AuthHandle, NvIndexHandle, NvIndexTpmHandle, SessionHandle, TpmHandle};
 use tss_esapi::interface_types::algorithm::{HashingAlgorithm, SignatureSchemeAlgorithm};
 use tss_esapi::interface_types::ecc::EccCurve;
-use tss_esapi::interface_types::reserved_handles::{NvAuth, Provision};
+use tss_esapi::interface_types::reserved_handles::{Hierarchy, NvAuth, Provision};
 use tss_esapi::interface_types::session_handles::{AuthSession, PolicySession};
 use tss_esapi::structures::{
-    CapabilityData, Digest, EncryptedSecret, IdObject, MaxNvBuffer, NvPublicBuilder, Public,
-    SymmetricDefinition,
+    CapabilityData, Digest, EncryptedSecret, IdObject, MaxBuffer, MaxNvBuffer, NvPublicBuilder,
+    PcrSelectionList, PcrSelectionListBuilder, PcrSlot, Public, SymmetricDefinition,
 };
 use tss_esapi::tss2_esys::TPM2_HANDLE;
 use tss_esapi::{Context, handles::KeyHandle};
@@ -17,6 +17,25 @@ use tss_esapi::{Context, handles::KeyHandle};
 use anyhow::Context as AnyhowContext;
 use std::convert::TryFrom;
 use tss_esapi::traits::Marshall;
+
+const NV_INDEX: u32 = 0x01000000; // Start of owner range
+const NV_INDEX_WITH_POLICY: u32 = NV_INDEX; // Separate index for policy-protected NV
+const MAX_CHUNK_SIZE: usize = 512;
+const TPM2_PT_NV_INDEX_MAX: u32 = 0x00000117;
+
+/// Default PCR indices for policy (7, 12, 13, 14)
+/// This are used by
+/// - #7: state of Secure Boot (breaks whenever Secure Boot changes)
+/// - PCR#12: stboot OS Detail Measurements (breaks whenever a different OS is loaded)
+/// - PCR#13: stboot OS Authority Measurements (breaks whenever a different trust policy or certificate is used)
+/// - PCR#14: stboot OS Human-readable ID string
+///
+/// For better explaintation visit
+/// - [System Transparency doc](https://docs.system-transparency.org/st-1.3.0/archive/ra/stboot-measurements/)
+/// - [UAPI Spec](https://uapi-group.org/specifications/specs/linux_tpm_pcr_registry/)
+///
+/// Use the `tpm3_pcrextend` for changing the values in testing
+pub const DEFAULT_POLICY_PCRS: &[u8] = &[7, 12, 13, 14];
 
 pub fn load_attestation_keys(
     context: &mut Context,
@@ -135,10 +154,6 @@ pub fn public_key_to_hex(public: &Public) -> anyhow::Result<String> {
     let bytes = public.marshall()?;
     Ok(hex::encode(bytes))
 }
-
-const NV_INDEX: u32 = 0x01000000; // Start of owner range
-const MAX_CHUNK_SIZE: usize = 512;
-const TPM2_PT_NV_INDEX_MAX: u32 = 0x00000117;
 
 pub fn get_max_nv_size(ctx: &mut Context) -> anyhow::Result<usize> {
     let (capability_data, _) = ctx
@@ -354,4 +369,295 @@ pub fn delete_nv_index(ctx: &mut Context, nv_handle: NvIndexHandle) -> anyhow::R
         .with_context(|| "Failed to clear session")?;
 
     Ok(())
+}
+
+/// Build a PCR selection list from PCR indices
+pub fn build_pcr_selection_list(
+    pcr_indices: &[u8],
+    hash_alg: HashingAlgorithm,
+) -> anyhow::Result<PcrSelectionList> {
+    let pcr_slots: Vec<PcrSlot> = pcr_indices
+        .iter()
+        .filter_map(|&idx| PcrSlot::try_from(idx as u32).ok())
+        .collect();
+
+    PcrSelectionListBuilder::new()
+        .with_selection(hash_alg, &pcr_slots)
+        .build()
+        .context("Failed to build PCR selection list")
+}
+
+/// Read PCR values and compute their concatenated hash digest
+fn read_and_hash_pcrs(
+    ctx: &mut Context,
+    pcr_selection_list: &PcrSelectionList,
+    hash_alg: HashingAlgorithm,
+) -> anyhow::Result<Digest> {
+    let (_, _, pcr_data) = ctx
+        .pcr_read(pcr_selection_list.clone())
+        .context("Failed to read PCR values")?;
+
+    let concatenated: Vec<u8> = pcr_data
+        .value()
+        .iter()
+        .flat_map(|d| d.as_bytes())
+        .copied()
+        .collect();
+
+    let pcr_digest = ctx
+        .hash(
+            MaxBuffer::try_from(concatenated)?,
+            hash_alg,
+            Hierarchy::Null,
+        )
+        .context("Failed to hash PCR values")?
+        .0;
+
+    Ok(pcr_digest)
+}
+
+/// Compute PCR policy digest using a trial session
+pub fn compute_pcr_policy_digest(
+    ctx: &mut Context,
+    pcr_indices: &[u8],
+    hash_alg: HashingAlgorithm,
+) -> anyhow::Result<Digest> {
+    anyhow::ensure!(!pcr_indices.is_empty(), "PCR indices cannot be empty");
+
+    let pcr_selection_list = build_pcr_selection_list(pcr_indices, hash_alg)?;
+    let pcr_digest = read_and_hash_pcrs(ctx, &pcr_selection_list, hash_alg)?;
+
+    // Start a trial policy session
+    let trial_session = ctx
+        .start_auth_session(
+            None,
+            None,
+            None,
+            SessionType::Trial,
+            SymmetricDefinition::AES_128_CFB,
+            hash_alg,
+        )
+        .context("Failed to start trial policy session")?
+        .ok_or_else(|| anyhow::anyhow!("Failed to create trial session"))?;
+
+    // Apply PolicyPCR to the trial session
+    let policy_session =
+        PolicySession::try_from(trial_session).context("Failed to convert to policy session")?;
+
+    ctx.policy_pcr(policy_session, pcr_digest, pcr_selection_list)
+        .context("Failed to apply PolicyPCR")?;
+
+    // Get the policy digest
+    let policy_digest = ctx
+        .policy_get_digest(policy_session)
+        .context("Failed to get policy digest")?;
+
+    // Flush the trial session
+    ctx.flush_context(SessionHandle::from(trial_session).into())
+        .context("Failed to flush trial session")?;
+
+    Ok(policy_digest)
+}
+
+/// Create a policy session authorized by current PCR values
+pub fn create_pcr_policy_session(
+    ctx: &mut Context,
+    pcr_indices: &[u8],
+    hash_alg: HashingAlgorithm,
+) -> anyhow::Result<AuthSession> {
+    anyhow::ensure!(!pcr_indices.is_empty(), "PCR indices cannot be empty");
+
+    let pcr_selection_list = build_pcr_selection_list(pcr_indices, hash_alg)?;
+    let pcr_digest = read_and_hash_pcrs(ctx, &pcr_selection_list, hash_alg)?;
+
+    // Start a real policy session
+    let policy_session = ctx
+        .start_auth_session(
+            None,
+            None,
+            None,
+            SessionType::Policy,
+            SymmetricDefinition::AES_128_CFB,
+            hash_alg,
+        )
+        .context("Failed to start policy session")?
+        .ok_or_else(|| anyhow::anyhow!("Failed to create policy session"))?;
+
+    // Apply PolicyPCR to satisfy the policy
+    let policy_session_handle =
+        PolicySession::try_from(policy_session).context("Failed to convert to policy session")?;
+
+    ctx.policy_pcr(policy_session_handle, pcr_digest, pcr_selection_list)
+        .context("Failed to apply PolicyPCR")?;
+
+    Ok(policy_session)
+}
+
+/// Get or create NV index handle with PCR policy protection
+pub fn get_nv_index_handle_with_policy(
+    ctx: &mut Context,
+    pcr_indices: &[u8],
+) -> anyhow::Result<(NvIndexHandle, usize)> {
+    anyhow::ensure!(!pcr_indices.is_empty(), "PCR indices cannot be empty");
+    let max_size = get_max_nv_size(ctx)?;
+    let nv_index_tpm_handle = NvIndexTpmHandle::new(NV_INDEX_WITH_POLICY)?;
+    let hash_alg = HashingAlgorithm::Sha256;
+
+    if nv_index_exists(ctx, NV_INDEX_WITH_POLICY)? {
+        let handle = ctx
+            .tr_from_tpm_public(TpmHandle::NvIndex(nv_index_tpm_handle))
+            .context("Failed to get existing NV index handle")?;
+
+        let nv_public = ctx
+            .nv_read_public(handle.into())
+            .context("Failed to read NV public area")?;
+
+        let existing_size = nv_public.0.data_size();
+
+        if existing_size != max_size {
+            eprintln!(
+                "Warning: Existing NV index has size {}, but TPM max is {}. Consider recreating.",
+                existing_size, max_size
+            );
+        }
+
+        Ok((handle.into(), existing_size))
+    } else {
+        // Compute policy digest for the NV index
+        let policy_digest = compute_pcr_policy_digest(ctx, pcr_indices, hash_alg)?;
+        let handle =
+            create_nv_index_with_policy(ctx, nv_index_tpm_handle, max_size, policy_digest)?;
+        Ok((handle, max_size))
+    }
+}
+
+fn create_nv_index_with_policy(
+    ctx: &mut Context,
+    nv_index_tpm_handle: NvIndexTpmHandle,
+    size: usize,
+    policy_digest: Digest,
+) -> anyhow::Result<NvIndexHandle> {
+    // Policy-based attributes: policy read/write instead of owner read/write
+    let attrs = NvIndexAttributesBuilder::new()
+        .with_pp_write(false)
+        .with_owner_write(false)
+        .with_policy_write(true)
+        .with_pp_read(false)
+        .with_owner_read(false)
+        .with_policy_read(true)
+        .with_no_da(true)
+        .build()?;
+
+    let nv_public = NvPublicBuilder::new()
+        .with_nv_index(nv_index_tpm_handle)
+        .with_index_name_algorithm(HashingAlgorithm::Sha256)
+        .with_index_attributes(attrs)
+        .with_data_area_size(size)
+        .with_index_auth_policy(policy_digest)
+        .build()?;
+
+    let session = ctx
+        .start_auth_session(
+            None,
+            None,
+            None,
+            SessionType::Hmac,
+            SymmetricDefinition::AES_128_CFB,
+            HashingAlgorithm::Sha256,
+        )?
+        .ok_or_else(|| anyhow::anyhow!("Failed to create auth session"))?;
+
+    ctx.execute_with_session(Some(session), |ctx| {
+        ctx.nv_define_space(Provision::Owner, None, nv_public)
+    })
+    .context("Failed to define NV space with policy")?;
+
+    ctx.flush_context(SessionHandle::from(session).into())
+        .with_context(|| "Failed to clear session")?;
+
+    ctx.tr_from_tpm_public(TpmHandle::NvIndex(nv_index_tpm_handle))
+        .map(Into::into)
+        .context("Failed to get newly created NV index handle")
+}
+
+/// Write data to NV index protected by PCR policy
+pub fn nv_write_data_with_policy(
+    ctx: &mut Context,
+    nv_handle: NvIndexHandle,
+    data: &[u8],
+    pcr_indices: &[u8],
+) -> anyhow::Result<()> {
+    let hash_alg = HashingAlgorithm::Sha256;
+    let mut offset = 0usize;
+
+    for chunk in data.chunks(MAX_CHUNK_SIZE) {
+        // Create a new policy session for each chunk (policy sessions are single-use)
+        let policy_session = create_pcr_policy_session(ctx, pcr_indices, hash_alg)?;
+
+        let buffer = MaxNvBuffer::try_from(chunk.to_vec()).context("Failed to create NV buffer")?;
+
+        ctx.execute_with_session(Some(policy_session), |ctx| {
+            ctx.nv_write(NvAuth::NvIndex(nv_handle), nv_handle, buffer, offset as u16)
+        })
+        .with_context(|| format!("Failed to write chunk at offset {}", offset))?;
+
+        ctx.flush_context(SessionHandle::from(policy_session).into())
+            .with_context(|| "Failed to clear policy session")?;
+
+        offset += chunk.len();
+    }
+
+    Ok(())
+}
+
+/// Read data from NV index protected by PCR policy
+pub fn nv_read_data_with_policy(
+    ctx: &mut Context,
+    nv_handle: NvIndexHandle,
+    pcr_indices: &[u8],
+) -> anyhow::Result<Vec<u8>> {
+    let hash_alg = HashingAlgorithm::Sha256;
+
+    let nv_public = ctx
+        .nv_read_public(nv_handle)
+        .context("Failed to read NV public area")?;
+
+    let size = nv_public.0.data_size();
+    let mut result = vec![0u8; size];
+    let mut offset = 0usize;
+
+    for chunk in result.chunks_mut(MAX_CHUNK_SIZE) {
+        let chunk_size = chunk.len() as u16;
+
+        // Create a new policy session for each chunk
+        let policy_session = create_pcr_policy_session(ctx, pcr_indices, hash_alg)?;
+
+        let data = ctx
+            .execute_with_session(Some(policy_session), |ctx| {
+                ctx.nv_read(
+                    NvAuth::NvIndex(nv_handle),
+                    nv_handle,
+                    chunk_size,
+                    offset as u16,
+                )
+            })
+            .with_context(|| format!("Failed to read chunk at offset {}", offset))?;
+
+        ctx.flush_context(SessionHandle::from(policy_session).into())
+            .with_context(|| "Failed to clear policy session")?;
+
+        let vec = data.to_vec();
+        anyhow::ensure!(
+            vec.len() == chunk.len(),
+            "Expected {} bytes at offset {}, got {}",
+            chunk.len(),
+            offset,
+            vec.len()
+        );
+
+        chunk.copy_from_slice(&vec);
+        offset += chunk.len();
+    }
+
+    Ok(result)
 }


### PR DESCRIPTION
To seal/unseal TPM keys we need to attest that we are on a trusted system,

this means sealing/unsealing based on the values of the following TPM PCR registes:

- PCR#7: state of Secure Boot (breaks whenever secure boot is 
- PCR#12: stboot OS Detail Measurements (breaks whenever a different OS is loaded)
- PCR#13: stboot OS Authority Measurements (breaks whenever a different trust policy or certificate is used)

https://uapi-group.org/specifications/specs/linux_tpm_pcr_registry/
https://docs.system-transparency.org/st-1.3.0/archive/ra/stboot-measurements/